### PR TITLE
Convert process to use web hosting and private containers. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pfx
+*.pem
+ping.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+certs/*
 *.pfx
 *.pem
 ping.txt

--- a/README.md
+++ b/README.md
@@ -1,148 +1,148 @@
 # Certificate Generation for an Azure Public IP with your DNS Prefix
 
-Many times we need TLS certificate issued by a public & trusted Certificate Authority, and this kind of certificate cost money and you need to own your domain. In Azure there are services that do not support self-sign certificates (Ex. Azure Front Door).  In order to do some testing on Azure, we can create a valid CA certificate for free. This article allows you generate a CA certificate for your subdomain inside Azure.
+Many times we need TLS certificate issued by a public and trusted certificate authority, and this kind of certificate typically costs money and you need to own your domain. In Azure there are services that do not support self-signed certificates (Ex. Azure Front Door).  In order to do some testing on Azure, we can create a public and valid CA certificate for free. This article allows you generate a CA certificate for your Public IP's domain prefix (i.e. `your-prefix.the-region.cloudapp.azure.com`).
 
-For example: `mysubdomain.eastus.cloudapp.azure.com`
-
-It is based on [Let's Encrypt®](https://letsencrypt.org/). Let's Encrypt is a non-profit certificate authority run by Internet Security Research Group (ISRG) that provides X.509 certificates for Transport Layer Security (TLS) encryption at no charge.
+It is based on [Let's Encrypt®](https://letsencrypt.org). Let's Encrypt is a non-profit certificate authority run by Internet Security Research Group (ISRG) that provides X.509 certificates for Transport Layer Security (TLS) encryption at no charge.
 ## Prerequisites
 
 1. An Azure subscription. If you don't have an Azure subscription, you can create a [free account](https://azure.microsoft.com/free).
-1. [Install Certbot](https://certbot.eff.org/). Certbot is a free, open source software tool for automatically using Let’s Encrypt certificates on manually-administrated websites to enable HTTPS.
-1. [Install OpenSSL](https://www.openssl.org/) command line tool. OpenSSL is a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.
+1. [Install Certbot](https://certbot.eff.org). Certbot is a free, open source software tool for automatically using Let’s Encrypt certificates on manually-administrated websites to enable HTTPS.
+1. [Install OpenSSL](https://www.openssl.org) command line tool. OpenSSL is a robust, commercial-grade, and full-featured toolkit for the Transport Layer Security (TLS) and Secure Sockets Layer (SSL) protocols. It is also a general-purpose cryptography library.
 1. [Install Azure CLI](https://docs.microsoft.com/cli/azure/install-azure-cli?view=azure-cli-latest) or you can perform this from Azure Cloud Shell by clicking below.
 
    [![Launch Azure Cloud Shell](https://docs.microsoft.com/azure/includes/media/cloud-shell-try-it/launchcloudshell.png)](https://shell.azure.com)
 
 ## Steps
 
-- Log in in your account and select the subscription
-  > :book: If you have one subscription the selection is not be needed
+- Log in to your Azure account and select the subscription.
 
-```bash
-## Login into azure
-az login
-## Choose your Azure subscription
-az account set -s XXXX
-```
+   ```bash
+   ## Login into Azure and set your subscription
+
+   az login
+   az account set -s XXXX
+   ```
 
 - :rocket: Create the Azure resources  
-  In order to create a certificate we need to demonstrate domain control. We are going to use a Azure Application Gateway on top of Azure Blob Storage to do that.
 
-```bash
-# Your resource group name
-RGNAME=rg-certi-let-encrypt
-# Azure location of the domain
-LOCATION=eastus
-# Your subdomain name
-DOMAIN_NAME=mysubdomain
+   In order to create a certificate we need to demonstrate domain ownership. We are going to use an Azure Application Gateway on top of Azure Blob storage to do that.
 
-# Set your domain name
-FQDN="$DOMAIN_NAME.$LOCATION.cloudapp.azure.com"
+   ```bash
+   # Your resource group name
+   RGNAME=rg-lets-encrypt-cert-validator
+   
+   # Azure location of the domain
+   LOCATION=eastus
+   
+   # Your subdomain (prefix) name
+   DOMAIN_NAME=mysubdomain
+   
+   # Set your domain name
+   FQDN="${DOMAIN_NAME}.${LOCATION}.cloudapp.azure.com"
+   
+   # Optional, you can use a pre-existing Public IP with the prior dns name set.
+   # PUBLIC_IP_RESOURCE_ID=
+   
+   # Resource group creation
+   az group create -n $RGNAME -l $LOCATION
+   
+   # Resource deployment. Public IP (with DNS prefix), Virtual Network, Storage Account and Application Gateway
+   az deployment group create -g $RGNAME -f resources-stamp.json --name cert-0001 -p location=${LOCATION} subdomainName=$   {DOMAIN_NAME} #ipResourceId=${PUBLIC_IP_RESOURCE_ID}
+   
+   # Get the Azure Storage Account name
+   STORAGE_ACCOUNT_NAME=$(az deployment group show -g $RGNAME -n cert-0001 --query properties.outputs.storageAccountName.value -o tsv)
+   
+   # Enable web hosting on the storage account (cannot be done via ARM)
+   az storage blob service-properties update --account-name $STORAGE_ACCOUNT_NAME --static-website true --auth-mode login
+   ```
 
-# Optional, we can use an existent Public IP with dns name
-# PUBLIC_IP_RESOURCE_ID=
+- :heavy_plus_sign: Upload test validation file, used to test connectivity and routing of Azure Application Gateway
 
-# Resource group creation
-az group create --name "${RGNAME}" --location "${LOCATION}"
+   ```bash
+   # Create a local test file
+   echo pong>ping.txt
+   
+   # Upload that file
+   az storage blob upload --account-name $STORAGE_ACCOUNT_NAME -c \$web -n ping -f ./ping.txt --auth-mode key
+   ```
 
-# Resource deployment. Public Ip (with DNS name), Virtual Network, Storage Account and Application Gateway
-az deployment group create -g "${RGNAME}" -f "resources-stamp.json"  --name "cert-0001" -p location=$LOCATION subdomainName=$DOMAIN_NAME #ipResourceId=$PUBLIC_IP_RESOURCE_ID
+- :heavy_check_mark: Checking if the resources created are working
 
-# Getting the Storage account name
-STORAGE_ACCOUNT_NAME=$(az deployment group show -g $RGNAME -n cert-0001 --query properties.outputs.storageAccountName.value -o tsv)
-```
+   ```bash
+   # Validate you can access the file directly from storage (should see "pong")
+   curl "$(az storage account show -g $RGNAME -n $STORAGE_ACCOUNT_NAME --query primaryEndpoints.web -o tsv)/ping"
+   
+   # The Azure Application Gateway is exposing the file properly (should see "pong")
+   curl http://${FQDN}/ping
+   
+   # The Azure Application Gateway rewrite rule is working for Let's Encrypt (should see "pong")
+   curl http://${FQDN}/.well-known/acme-challenge/ping
+   ```
 
-- :heavy_plus_sign: Add a Azure Blob container and upload a file
+- :key: Generate certificate by using [Certbot](https://certbot.eff.org/)
 
-```bash
-# Create a Container on the Storage Account provided
-az storage container create --account-name $STORAGE_ACCOUNT_NAME --name verificationdata --auth-mode login --public-access container
+   Execute a command like the following with administration privilege.
 
-# Create a Local File
-echo Microsoft>test.txt
+   ```bash
+   sudo certbot certonly --email changeme@mail.com -d $FQDN --agree-tos --manual
+   ```
 
-# Upload that file
-az storage blob upload \
- --account-name $STORAGE_ACCOUNT_NAME \
- --container-name verificationdata \
- --name test.txt \
- --file ./test.txt \
- --auth-mode key
+   Before pressing Enter, you need to follow the Certbot instructions in another console window.
 
-```
+   ![Console output from certbot](./cerbot.png)
 
-- :heavy_check_mark: Checking the if the resource created are working
+   1. Create a file name with the name presented by Certbot during the execution, with a `.txt` extension and add the content inside as instructed. For example,
 
-```bash
-# We can access the file inside the blob
-curl https://$STORAGE_ACCOUNT_NAME.blob.core.windows.net/verificationdata/test.txt
+   ```bash
+   echo "-Nahn2wS1fLeqGwqjDBIWxSpL5U4mlb_oA50wsPeoqk.T_a4tluV9By4PqiMY4Xz5iLe5ty1whK_vNK21LY6ZTU">-Nahn2wS1fLeqGwqjDBIWxSpL5U4mlb_oA50wsPeoqk.txt
+   ```
 
-# The Azure Application Gateway is exposing the Azure Blob
-curl http://$FQDN/verificationdata/test.txt
+   1. Upload the generated file inside the _$web_ container in any way (by command line or azure portal as you prefer) Ex:
 
-# The Azure Application Gateway rewrite rule is working
-curl http://$FQDN/.well-known/acme-challenge/test
-```
+      ```bash
+      az storage blob upload                                   \
+        --account-name $STORAGE_ACCOUNT_NAME                   \
+        -c \$web                                               \
+        -n "-Nahn2wS1fLeqGwqjDBIWxSpL5U4mlb_oA50wsPeoqk"       \
+        -f "./-Nahn2wS1fLeqGwqjDBIWxSpL5U4mlb_oA50wsPeoqk.txt" \
+        --auth-mode key
+      ```
 
-- :key: Generate certificate base on [Cerbot](https://certbot.eff.org/)
+   1. Test the url that certbot is expecting. (Should receive the text from above.)
 
-Please, Execute a command like the following with administration privilege
+      ```bash
+      curl http://${FQDN}/.well-known/acme-challenge/-Nahn2wS1fLeqGwqjDBIWxSpL5U4mlb_oA50wsPeoqk
+      ```
 
-```bash
-sudo certbot certonly --email changeme@mail.com -d $FQDN --agree-tos --manual
-```
+   1. If the test is working, please press Enter
 
-At this point you need to follow the Cerbot instructions
-![At this point you need to follow the Cerbot instructions](./cerbot.png)
-
-1. Create a file name with the name presenting by Cerbot during the execution, with txt extension,  
-   `Ex: -Nahn2wS1fLeqGwqjDBIWxSpL5U4mlb_oA50wsPeoqk.txt`
-2. Add inside the content presented by Cerbot,  
-   `Ex: -Nahn2wS1fLeqGwqjDBIWxSpL5U4mlb_oA50wsPeoqk.T_a4tluV9By4PqiMY4Xz5iLe5ty1whK_vNK21LY6ZTU`
-3. Upload the generated file inside the _verificationdata_ container in any way (by command line or azure portal as you prefer) Ex:
-
-```bash
-az storage blob upload \
- --account-name $STORAGE_ACCOUNT_NAME \
- --container-name verificationdata \
- --name -Nahn2wS1fLeqGwqjDBIWxSpL5U4mlb_oA50wsPeoqk.txt \
- --file ./-Nahn2wS1fLeqGwqjDBIWxSpL5U4mlb_oA50wsPeoqk.txt \
- --auth-mode key
-```
-
-4. Test the url presented by cerbot, Ex:
-
-```bash
-curl http://mysubdomain.eastus.cloudapp.azure.com/.well-known/acme-challenge/-Nahn2wS1fLeqGwqjDBIWxSpL5U4mlb_oA50wsPeoqk
-```
-
-5. If the test is working, please press Enter
-6. You should get a message about the cert was generated
+   1. You should get a message that the cert was generated.
 
 - :page_with_curl: We need to generate the pfx
 
-1. Take the key files
+   1. Take the key files
 
-```bash
-mkdir files
-sudo cp /etc/letsencrypt/live/$FQDN/privkey.pem ./files
-sudo cp /etc/letsencrypt/live/$FQDN/cert.pem ./files
-sudo cp /etc/letsencrypt/live/$FQDN/chain.pem ./files
-cd files
-```
+      ```bash
+      mkdir files
+      sudo cp /etc/letsencrypt/live/${FQDN}/privkey.pem ./files
+      sudo cp /etc/letsencrypt/live/${FQDN}/cert.pem ./files
+      sudo cp /etc/letsencrypt/live/${FQDN}/chain.pem ./files
+      cd files
+      ```
 
-2. Generate pfx with or without password as you need
+   1. Generate pfx with or without password as you need
 
-```bash
-#Password-less
-openssl pkcs12 -export -out $DOMAIN_NAME.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass:
-#With password
-openssl pkcs12 -export -out $DOMAIN_NAME.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem
-```
+      ```bash
+      # Password-less
+      openssl pkcs12 -export -out ${DOMAIN_NAME}.pfx -inkey privkey.pem -in cert.pem -certfile       chain.pem -passout pass:
+      
+      # Or with password
+      openssl pkcs12 -export -out ${DOMAIN_NAME}.pfx -inkey privkey.pem -in cert.pem -certfile       chain.pem
+      ```
 
-- :thumbsup: You have your CA valid pfx certificate for your domain on the directory  
-  You will able to find $DOMAIN_NAME.pfx file on the current folder
+- :thumbsup: You have your CA valid pfx certificate for your domain on the directory.
+
+   You will able to find `$DOMAIN_NAME.pfx` file on the current folder.
 
 ### :broom: Delete Azure resources
 
@@ -150,29 +150,29 @@ openssl pkcs12 -export -out $DOMAIN_NAME.pfx -inkey privkey.pem -in cert.pem -ce
 az group delete -n $RGNAME --yes
 ```
 
-### :book: Generate extra certificate
+### :book: Generate more certificates
 
-If you need to generate other certificates in *the same region*, before deleting the resources, you could
+If you need to generate more certificates in *the same region*, before deleting the resources, you could:
 
 1. Set the new values in the variables, Ex.
 
-```bash
-FQDN=mysecondsubdomain.eastus.cloudapp.azure.com
-DOMAIN_NAME=mysecondsubdomain
-```
+   ```bash
+   FQDN=mysecondsubdomain.eastus.cloudapp.azure.com
+   DOMAIN_NAME=mysecondsubdomain
+   ```
 
-2. In Azure Portal Change the name for the Public IP  
+1. In Azure Portal Change the name for the Public IP
+
    Public IP -> Configuration -> DNS name label  
-   Set the same value than $DOMAIN_NAME
+   Set the same value than `$DOMAIN_NAME`
 
-3. Go back to the root folder
+1. Go back to the root folder
 
-```bash
-cd ..
-```
+   ```bash
+   cd ..
+   ```
 
-4. Start again on the step "Generate certificate base on [Certbot](https://certbot.eff.org/)"
-
+1. Start again on the step "Generate certificate base on [Certbot](https://certbot.eff.org/)"
 
 ## Scripting Cert Generation
 It is an option to generate the certificate running a script which will execute automatically all for you. It will generate subdomain.pfx in your directory. All the resources are created, then the certificate is generated, and finally the resources are deleted. The script generate the certificate for a PIP (Public IP) which already exist (the last parameter). Anyway, you could delete that parameter and adjust the script.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Certificate Generation for an Azure Public IP with your DNS Prefix
 
-Many times we need TLS certificate issued by a public and trusted certificate authority, and this kind of certificate typically costs money and you need to own your domain. In Azure there are services that do not support self-signed certificates (Ex. Azure Front Door).  In order to do some testing on Azure, we can create a public and valid CA certificate for free. This article allows you generate a CA certificate for your Public IP's domain prefix (i.e. `your-prefix.the-region.cloudapp.azure.com`).
+In Azure there are services that do not support self-signed certificates (Ex. Azure Front Door).  In order to do some testing on Azure, we can create a public and valid CA certificate for free. This article allows you generate a CA certificate for your Public IP's domain prefix (i.e. `your-prefix.the-region.cloudapp.azure.com`).
 
 It is based on [Let's Encrypt®](https://letsencrypt.org). Let's Encrypt is a non-profit certificate authority run by Internet Security Research Group (ISRG) that provides X.509 certificates for Transport Layer Security (TLS) encryption at no charge.
 ## Prerequisites
@@ -20,7 +20,7 @@ It is based on [Let's Encrypt®](https://letsencrypt.org). Let's Encrypt is a no
    ## Login into Azure and set your subscription
 
    az login
-   az account set -s XXXX
+   az account set -s <subscription-id>
    ```
 
 - :rocket: Create the Azure resources  
@@ -176,7 +176,7 @@ If you need to generate more certificates in *the same region*, before deleting 
 
 ## Scripting certificate generation
 
-It is an option to generate the certificate running a script which will execute automatically all for you. It will generate subdomain.pfx in your directory. All the resources are created, then the certificate is generated, and finally the resources are deleted. The script generates the certificate for a PIP (Public IP) which already exist.
+It is an option to generate the certificate running a script which will execute automatically all for you. It will generate `subdomain.pfx` in your directory. All the resources are created, then the certificate is generated, and finally the resources are deleted. The script generates the certificate for a PIP (Public IP) which already exist.
 
 ```bash
 ./generate-cert.sh <Existing PIP resource Id>

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ It is based on [Let's Encrypt®](https://letsencrypt.org). Let's Encrypt is a no
    Execute a command like the following with administration privilege.
 
    ```bash
-   sudo certbot certonly --email changeme@mail.com -d $FQDN --agree-tos --manual
+   certbot certonly --email changeme@mail.com --agree-tos --manual --manual-auth-hook "./authenticator.sh ${STORAGE_ACCOUNT_NAME}" -d $FQDN --config-dir ./certs/etc/letsencrypt --work-dir ./certs/var/lib/letsencrypt --logs-dir ./certs/var/log/letsencrypt
    ```
 
    Before pressing Enter, you need to follow the Certbot instructions in another console window.
@@ -120,19 +120,11 @@ It is based on [Let's Encrypt®](https://letsencrypt.org). Let's Encrypt is a no
 
 - :page_with_curl: We need to generate the pfx
 
-   1. Take the key files
-
-      ```bash
-      mkdir files
-      sudo cp /etc/letsencrypt/live/${FQDN}/privkey.pem ./files
-      sudo cp /etc/letsencrypt/live/${FQDN}/cert.pem ./files
-      sudo cp /etc/letsencrypt/live/${FQDN}/chain.pem ./files
-      cd files
-      ```
-
    1. Generate pfx with or without password as you need
 
       ```bash
+      cd ./certs/etc/letsencrypt/live/${FQDN}/
+
       # Password-less
       openssl pkcs12 -export -out ${DOMAIN_NAME}.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass:
       
@@ -169,7 +161,7 @@ If you need to generate more certificates in *the same region*, before deleting 
 1. Go back to the root folder
 
    ```bash
-   cd ..
+   cd -
    ```
 
 1. Start again on the step "Generate certificate base on [Certbot](https://certbot.eff.org/)"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ It is based on [Let's Encrypt®](https://letsencrypt.org). Let's Encrypt is a no
    az group create -n $RGNAME -l $LOCATION
    
    # Resource deployment. Public IP (with DNS prefix), Virtual Network, Storage Account and Application Gateway
-   az deployment group create -g $RGNAME -f resources-stamp.json --name cert-0001 -p location=${LOCATION} subdomainName=$   {DOMAIN_NAME} #ipResourceId=${PUBLIC_IP_RESOURCE_ID}
+   az deployment group create -g $RGNAME -f resources-stamp.json --name cert-0001 -p location=${LOCATION} subdomainName=${DOMAIN_NAME} #ipResourceId=${PUBLIC_IP_RESOURCE_ID}
    
    # Get the Azure Storage Account name
    STORAGE_ACCOUNT_NAME=$(az deployment group show -g $RGNAME -n cert-0001 --query properties.outputs.storageAccountName.value -o tsv)
@@ -134,10 +134,10 @@ It is based on [Let's Encrypt®](https://letsencrypt.org). Let's Encrypt is a no
 
       ```bash
       # Password-less
-      openssl pkcs12 -export -out ${DOMAIN_NAME}.pfx -inkey privkey.pem -in cert.pem -certfile       chain.pem -passout pass:
+      openssl pkcs12 -export -out ${DOMAIN_NAME}.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass:
       
       # Or with password
-      openssl pkcs12 -export -out ${DOMAIN_NAME}.pfx -inkey privkey.pem -in cert.pem -certfile       chain.pem
+      openssl pkcs12 -export -out ${DOMAIN_NAME}.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem
       ```
 
 - :thumbsup: You have your CA valid pfx certificate for your domain on the directory.
@@ -174,11 +174,12 @@ If you need to generate more certificates in *the same region*, before deleting 
 
 1. Start again on the step "Generate certificate base on [Certbot](https://certbot.eff.org/)"
 
-## Scripting Cert Generation
-It is an option to generate the certificate running a script which will execute automatically all for you. It will generate subdomain.pfx in your directory. All the resources are created, then the certificate is generated, and finally the resources are deleted. The script generate the certificate for a PIP (Public IP) which already exist (the last parameter). Anyway, you could delete that parameter and adjust the script.
+## Scripting certificate generation
+
+It is an option to generate the certificate running a script which will execute automatically all for you. It will generate subdomain.pfx in your directory. All the resources are created, then the certificate is generated, and finally the resources are deleted. The script generates the certificate for a PIP (Public IP) which already exist.
 
 ```bash
-./generate-cert.sh <location> <subdomain> <FQDN> <PIP resource Id>
+./generate-cert.sh <Existing PIP resource Id>
 ```
 ## Contributions
 

--- a/authenticator.sh
+++ b/authenticator.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 STORAGE_ACCOUNT_NAME=$1
 
 echo $CERTBOT_VALIDATION>${CERTBOT_TOKEN}.txt

--- a/authenticator.sh
+++ b/authenticator.sh
@@ -1,14 +1,9 @@
 STORAGE_ACCOUNT_NAME=$1
-STORAGE_CONNECTION_STRING=$2
 
-echo $CERTBOT_VALIDATION>$CERTBOT_TOKEN.txt
+echo $CERTBOT_VALIDATION>${CERTBOT_TOKEN}.txt
 
-az storage blob upload \
- --connection-string $STORAGE_CONNECTION_STRING \
- --account-name $STORAGE_ACCOUNT_NAME \
- --container-name verificationdata \
- --name $CERTBOT_TOKEN.txt \
- --file ./$CERTBOT_TOKEN.txt \
- --auth-mode key
+echo "Uploading validation token to $STORAGE_ACCOUNT_NAME"
 
-rm $CERTBOT_TOKEN.txt
+az storage blob upload --account-name $STORAGE_ACCOUNT_NAME -c \$web -n "${CERTBOT_TOKEN}" -f "./${CERTBOT_TOKEN}.txt" --auth-mode key --only-show-errors
+
+rm ${CERTBOT_TOKEN}.txt

--- a/generate-cert.sh
+++ b/generate-cert.sh
@@ -1,47 +1,47 @@
-LOCATION=$1
-SUBDOMAIN=$2
-FQDN=$3
-IP_RESOURCE_ID=$4
+IP_RESOURCE_ID=$1
 
-RGNAME="rg-cert-let-encrypt-${LOCATION}"
-echo $LOCATION
-echo $RGNAME
-echo $SUBDOMAIN
-echo $FQDN
-echo $IP_RESOURCE_ID
+LOCATION=$(az network public-ip show --ids $IP_RESOURCE_ID --query location -o tsv)
+RGNAME="rg-lets-encrypt-cert-validator-${LOCATION}"
 
-az group create --name ${RGNAME} --location ${LOCATION}
+FQDN=$(az network public-ip show --ids $IP_RESOURCE_ID --query dnsSettings.fqdn -o tsv)
+SUBDOMAIN=$(az network public-ip show --ids $IP_RESOURCE_ID --query dnsSettings.domainNameLabel -o tsv)
 
-az deployment group create -g "${RGNAME}" --template-file "./resources-stamp.json"  --name "cert-0001" --parameters location=$LOCATION subdomainName=$SUBDOMAIN ipResourceId=$IP_RESOURCE_ID
+echo "Location: $LOCATION"
+echo "DNS Prefix: $SUBDOMAIN"
+echo "FQDN: $FQDN"
+echo "Existing IP Resource ID: $IP_RESOURCE_ID"
 
-STORAGE_ACCOUNT_NAME=$(az deployment group show -g $RGNAME -n cert-0001 --query properties.outputs.storageAccountName.value -o tsv)
-az storage container create --account-name $STORAGE_ACCOUNT_NAME --name verificationdata --auth-mode login --public-access container
-STORAGE_CONNECTION_STRING=$(az storage account show-connection-string -g $RGNAME -n $STORAGE_ACCOUNT_NAME --query "connectionString")
+echo "Creating temporary Resource Group $RGNAME"
+az group create -n $RGNAME -l $LOCATION
 
-echo Storage Account: $STORAGE_ACCOUNT_NAME
-echo Storage Account - connectionString: $STORAGE_CONNECTION_STRING
+echo "Deploying Azure resources used in validation; this may take 20 minutes."
+az deployment group create -g $RGNAME -f resources-stamp.json -n $SUBDOMAIN -p location=${LOCATION} subdomainName=${SUBDOMAIN} ipResourceId=${IP_RESOURCE_ID}
 
-echo Microsoft>test.txt
+STORAGE_ACCOUNT_NAME=$(az deployment group show -g $RGNAME -n $SUBDOMAIN --query properties.outputs.storageAccountName.value -o tsv)
 
-az storage blob upload \
- --connection-string $STORAGE_CONNECTION_STRING \
- --account-name $STORAGE_ACCOUNT_NAME \
- --container-name verificationdata \
- --name test.txt \
- --file ./test.txt \
- --auth-mode key
+echo "Enabling web hosting on $STORAGE_ACCOUNT_NAME"
+az storage blob service-properties update --account-name $STORAGE_ACCOUNT_NAME --static-website true --auth-mode login
 
-sudo certbot certonly --manual --manual-auth-hook "./authenticator.sh $STORAGE_ACCOUNT_NAME $STORAGE_CONNECTION_STRING" -d $FQDN
+echo "Uploading placeholder to storage"
+echo pong>ping.txt
+az storage blob upload --account-name $STORAGE_ACCOUNT_NAME -c \$web -n ping -f ./ping.txt --auth-mode key
 
-sudo cp /etc/letsencrypt/live/$FQDN/privkey.pem .
-sudo cp /etc/letsencrypt/live/$FQDN/cert.pem .
-sudo cp /etc/letsencrypt/live/$FQDN/chain.pem .
-openssl pkcs12 -export -out $SUBDOMAIN.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass:
+echo "Starting cert generation and validation"
+sudo certbot certonly --manual --manual-auth-hook "./authenticator.sh ${STORAGE_ACCOUNT_NAME}" -d $FQDN
 
-echo "Deleting resources"
-az group delete -n $RGNAME --yes
-rm test.txt
+echo "Converting cert to pfx"
+sudo cp /etc/letsencrypt/live/${FQDN}/privkey.pem .
+sudo cp /etc/letsencrypt/live/${FQDN}/cert.pem .
+sudo cp /etc/letsencrypt/live/${FQDN}/chain.pem .
+openssl pkcs12 -export -out ${SUBDOMAIN}.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass:
+
+echo "Deleting Azure resources"
+#az group delete -n $RGNAME --yes
+
+echo "Deleting temporary local files"
+rm ping.txt
 rm privkey.pem
 rm cert.pem
 rm chain.pem
-echo "Your certificate: $SUBDOMAIN.pfx"
+
+echo "Your certificate: ${SUBDOMAIN}.pfx"

--- a/generate-cert.sh
+++ b/generate-cert.sh
@@ -36,7 +36,7 @@ sudo cp /etc/letsencrypt/live/${FQDN}/chain.pem .
 openssl pkcs12 -export -out ${SUBDOMAIN}.pfx -inkey privkey.pem -in cert.pem -certfile chain.pem -passout pass:
 
 echo "Deleting Azure resources"
-#az group delete -n $RGNAME --yes
+az group delete -n $RGNAME --yes
 
 echo "Deleting temporary local files"
 rm ping.txt

--- a/resources-stamp.json
+++ b/resources-stamp.json
@@ -1,42 +1,43 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "subdomainName": {
             "type": "String",
             "metadata": {
-                "description": "The name used for azure subdomain which we want the cert for"
+                "description": "DNS label prefix: <prefix>.<region>.cloudapp.azure.com"
             }
         },
         "location": {
             "type": "string",
             "metadata": {
-                "description": "Domain region"
+                "description": "Domain region: <prefix>.<region>.cloudapp.azure.com"
             }
         },
         "ipResourceId":{
             "type": "string",
             "defaultValue": "newIp",
             "metadata": {
-                "description": "ipResouceId"
+                "description": "Existing Public IP resource ID or 'newIp' to indicate an IP address should be created."
             }
         }
     },
     "variables": {
-        "subdomain" : "[replace(parameters('subdomainName'),'.','')]",
-        "storageAccountName": "[replace(replace(variables('subdomain'), '_', ''),'-','')]",
-        "appGatewayPublicIp":"[if(equals(parameters('ipResourceId'),'newIp'), resourceId('Microsoft.Network/publicIpAddresses',variables('subdomain')), parameters('ipResourceId'))]"
+        "subdomain" : "[replace(parameters('subdomainName'), '.', '')]",
+        "storageAccountName": "[replace(replace(variables('subdomain'), '_', ''), '-', '')]",
+        "appGatewayPublicIp":"[if(equals(parameters('ipResourceId'), 'newIp'), resourceId('Microsoft.Network/publicIpAddresses', variables('subdomain')), parameters('ipResourceId'))]"
     },
     "resources": [
         {
+            "condition" : "[equals(parameters('ipResourceId'), 'newIp')]",
             "type": "Microsoft.Network/publicIPAddresses",
-            "apiVersion": "2020-05-01",
-            "condition" : "[equals(parameters('ipResourceId'),'newIp')]",
+            "apiVersion": "2020-11-01",
             "name": "[variables('subdomain')]",
             "location": "[parameters('location')]",
             "sku": {
                 "name": "Standard"
             },
+            "zones": [],
             "properties": {
                 "publicIPAllocationMethod": "Static",
                 "idleTimeoutInMinutes": 4,
@@ -49,7 +50,7 @@
         },
         {
             "type": "Microsoft.Storage/storageAccounts",
-            "apiVersion": "2020-08-01-preview",
+            "apiVersion": "2021-01-01",
             "name": "[variables('storageAccountName')]",
             "location":  "[parameters('location')]",
             "sku": {
@@ -59,7 +60,8 @@
             "kind": "StorageV2",
             "properties": {
                 "minimumTlsVersion": "TLS1_2",
-                "allowBlobPublicAccess": true,
+                "allowBlobPublicAccess": false,
+                "allowSharedKeyAccess": true,
                 "networkAcls": {
                     "bypass": "AzureServices",
                     "virtualNetworkRules": [],
@@ -69,43 +71,16 @@
                 "supportsHttpsTrafficOnly": true,
                 "encryption": {
                     "services": {
-                        "file": {
-                            "keyType": "Account",
-                            "enabled": true
-                        },
-                        "blob": {
-                            "keyType": "Account",
-                            "enabled": true
-                        }
+                        "blob": {}
                     },
                     "keySource": "Microsoft.Storage"
                 },
                 "accessTier": "Hot"
             }
-        },        
-        {
-            "type": "Microsoft.Storage/storageAccounts/blobServices",
-            "apiVersion": "2020-08-01-preview",
-            "name": "[concat(variables('storageAccountName'), '/default')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
-            ],
-            "sku": {
-                "name": "Standard_LRS",
-                "tier": "Standard"
-            },
-            "properties": {
-                "cors": {
-                    "corsRules": []
-                },
-                "deleteRetentionPolicy": {
-                    "enabled": false
-                }
-            }
-        },        
+        },      
         {
             "type": "Microsoft.Network/virtualNetworks",
-            "apiVersion": "2020-05-01",
+            "apiVersion": "2020-11-01",
             "name": "[variables('subdomain')]",
             "location":  "[parameters('location')]",
             "properties": {
@@ -115,52 +90,45 @@
                     ]
                 },
                 "subnets": [
-                ],
-                "virtualNetworkPeerings": [],
-                "enableDdosProtection": false,
-                "enableVmProtection": false
-            }
-        },
-        {  
-            "type": "Microsoft.Network/virtualNetworks/subnets",
-            "apiVersion": "2020-05-01",
-            "name": "[concat(variables('subdomain'), '/default')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks', variables('subdomain'))]"
-            ],
-            "properties": {
-                "addressPrefix": "172.20.0.0/24",
-                "delegations": [],
-                "privateEndpointNetworkPolicies": "Enabled",
-                "privateLinkServiceNetworkPolicies": "Enabled"
+                    {
+                        "name": "default",
+                        "properties": {
+                            "addressPrefix": "172.20.0.0/24"
+                        }
+                    }
+                ]
             }
         },
         {
             "type": "Microsoft.Network/applicationGateways",
-            "apiVersion": "2020-05-01",
+            "apiVersion": "2020-11-01",
             "name": "[variables('subdomain')]",
             "location":  "[parameters('location')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('subdomain'),'default')]",
-                "[resourceId('Microsoft.Network/publicIpAddresses',variables('subdomain'))]"
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('subdomain'))]",
+                "[resourceId('Microsoft.Network/publicIpAddresses', variables('subdomain'))]",
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
             ],
             "properties": {
                 "sku": {
                     "name": "Standard_v2",
-                    "tier": "Standard_v2"
+                    "tier": "Standard_v2",
+                    "capacity": 1
                 },
                 "gatewayIPConfigurations": [
                     {
                         "name": "appGatewayIpConfig",
                         "properties": {
                             "subnet": {
-                                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('subdomain'),'default')]"
+                                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('subdomain'), 'default')]"
                             }
                         }
                     }
                 ],
                 "sslCertificates": [],
                 "trustedRootCertificates": [],
+                "trustedClientCertificates": [],
+                "sslProfiles": [],
                 "frontendIPConfigurations": [
                     {
                         "name": "appGwPublicFrontendIp",
@@ -186,7 +154,7 @@
                         "properties": {
                             "backendAddresses": [
                                 {
-                                    "fqdn": "[concat(variables('storageAccountName'),'.blob.core.windows.net')]"
+                                    "fqdn": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))).primaryEndpoints.web, 'https://', ''), '/', '')]"
                                 }
                             ]
                         }
@@ -202,7 +170,7 @@
                             "pickHostNameFromBackendAddress": true,
                             "requestTimeout": 20,
                             "probe": {
-                                "id": "[concat(resourceId('Microsoft.Network/applicationGateways', variables('subdomain')), concat('/probes/', variables('subdomain')))]"
+                                "id": "[concat(resourceId('Microsoft.Network/applicationGateways', variables('subdomain')), '/probes/', variables('subdomain'))]"
                             }
                         }
                     }
@@ -230,16 +198,16 @@
                         "properties": {
                             "ruleType": "Basic",
                             "httpListener": {
-                                "id": "[concat(resourceId('Microsoft.Network/applicationGateways', variables('subdomain')), concat('/httpListeners/', variables('subdomain')))]"
+                                "id": "[concat(resourceId('Microsoft.Network/applicationGateways', variables('subdomain')), '/httpListeners/', variables('subdomain'))]"
                             },
                             "backendAddressPool": {
-                                "id": "[concat(resourceId('Microsoft.Network/applicationGateways', variables('subdomain')), concat('/backendAddressPools/', variables('subdomain')))]"
+                                "id": "[concat(resourceId('Microsoft.Network/applicationGateways', variables('subdomain')), '/backendAddressPools/', variables('subdomain'))]"
                             },
                             "backendHttpSettings": {
-                                "id": "[concat(resourceId('Microsoft.Network/applicationGateways', variables('subdomain')), concat('/backendHttpSettingsCollection/', variables('subdomain')))]"
+                                "id": "[concat(resourceId('Microsoft.Network/applicationGateways', variables('subdomain')), '/backendHttpSettingsCollection/', variables('subdomain'))]"
                             },
                             "rewriteRuleSet": {
-                                "id": "[concat(resourceId('Microsoft.Network/applicationGateways', variables('subdomain')), concat('/rewriteRuleSets/', variables('subdomain')))]"
+                                "id": "[concat(resourceId('Microsoft.Network/applicationGateways', variables('subdomain')), '/rewriteRuleSets/', variables('subdomain'))]"
                             }
                         }
                     }
@@ -249,10 +217,10 @@
                         "name": "[variables('subdomain')]",
                         "properties": {
                             "protocol": "Https",
-                            "path": "/verificationdata/test.txt",
-                            "interval": 30,
-                            "timeout": 30,
-                            "unhealthyThreshold": 3,
+                            "path": "/ping",
+                            "interval": 20,
+                            "timeout": 10,
+                            "unhealthyThreshold": 2,
                             "pickHostNameFromBackendHttpSettings": true,
                             "minServers": 0,
                             "match": {}
@@ -279,7 +247,7 @@
                                         "requestHeaderConfigurations": [],
                                         "responseHeaderConfigurations": [],
                                         "urlConfiguration": {
-                                            "modifiedPath": "/verificationdata/{var_uri_path_1}.txt",
+                                            "modifiedPath": "/{var_uri_path_1}",
                                             "reroute": false
                                         }
                                     }
@@ -290,11 +258,7 @@
                 ],
                 "redirectConfigurations": [],
                 "privateLinkConfigurations": [],
-                "enableHttp2": false,
-                "autoscaleConfiguration": {
-                    "minCapacity": 0,
-                    "maxCapacity": 2
-                }
+                "enableHttp2": false
             }
         }
     ],


### PR DESCRIPTION
* Converted to use private containers, exposed via the static hosting endpoint.
* Updated ARM API versions
* Wording and formatting change in the readmes
* Script flow simplification
* Added gitignore for some of the generated files.  They should clean themselves up, but in case they don't, we don't want certs being checked in
* Convert to not requiring the use of `sudo`
* Add `--no-wait` to resource cleanup
* Made it so that the ARM template can be re-run (idempotent)
* Simplified the ARM template in some areas that had items in it that were extranious

Once this lands then I'll update the matching one in the Multi-Region RA -- that RA is currently pointing to a snapshot of the ARM template and has its own scripts, so no harm in deploying this change here first.  I'll be updating the Multi-Region RA after this is merged in mspnp/aks-baseline-multi-region#24